### PR TITLE
feat: isolate styles from page contents

### DIFF
--- a/src/styles/core.css
+++ b/src/styles/core.css
@@ -1,10 +1,17 @@
 /* Core styles for Carbon Visualizer extension */
 
+:where(#carbon-visualizer-welcome-panel,
+#carbon-visualizer-welcome-panel *,
+#carbon-visualizer-welcome-panel *::before,
+#carbon-visualizer-welcome-panel *::after) {
+  all: initial;
+}
+
 /* TODO: these green values were generated using https://oklchroma.utilitybend.com/ and are not part of any design specs.
  * The custom properties are used in this file and welcome.css.
  * Feel free to remove them in favor of our own color palette!
  */
-:root {
+#carbon-visualizer-welcome-panel {
   /* greens */
   --cv-primary-green: hsl(114deg 64.9% 32.0%);
   --cv-primary-green-base: 0.05;
@@ -18,7 +25,7 @@
   --cv-primary-green-80: oklch(from var(--cv-primary-green) 80% calc(var(--cv-primary-green-base) + (sin(0.3 * pi) * c)) h);
   --cv-primary-green-90: oklch(from var(--cv-primary-green) 90% calc(var(--cv-primary-green-base) + (sin(0.2 * pi) * c)) h);
   --cv-primary-green-100: oklch(from var(--cv-primary-green) 100% calc(var(--cv-primary-green-base) + (sin(0.1 * pi) * c)) h);
-  
+
   /* neutrals */
   --cv-black: hsl(0deg 0% 0%);
   --cv-white: hsl(0deg 0% 100%);

--- a/src/styles/core.css
+++ b/src/styles/core.css
@@ -39,124 +39,124 @@
       margin-block-start: 1em;
     }
   }
-}
 
-.cv-panel {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 18.75rem;
-  height: 100vh;
-  z-index: 999999;
-  transform: translateX(-100%);
-  transition: transform 0.3s ease;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-  box-shadow: 0.125rem 0 0.625rem var(--cv-black);
-  overflow-y: auto;
-}
+  &.cv-panel {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 18.75rem;
+    height: 100vh;
+    z-index: 999999;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+    box-shadow: 0.125rem 0 0.625rem var(--cv-black);
+    overflow-y: auto;
+  }
 
-.cv-panel--visible {
-  transform: translateX(0);
-}
+  &.cv-panel--visible {
+    transform: translateX(0);
+  }
 
-/* Panel header */
-.cv-header {
-  display: flex;
-  gap: 1rem;
-  align-items: center;
-  padding: 1rem 1.5rem;
-  /* TODO: The `border-bottom` color is equal to `--cv-color-gray-50` and should be replaced with the variable when implemented */
-  border-bottom: 1px solid oklch(from oklch(50.0% 0.000 0) 50% calc(0 + (sin(0.6 * pi) * c)) h);
-  background-color: var(--cv-white);
-}
+  /* Panel header */
+  .cv-header {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    padding: 1rem 1.5rem;
+    /* TODO: The `border-bottom` color is equal to `--cv-color-gray-50` and should be replaced with the variable when implemented */
+    border-bottom: 1px solid oklch(from oklch(50.0% 0.000 0) 50% calc(0 + (sin(0.6 * pi) * c)) h);
+    background-color: var(--cv-white);
+  }
 
-.cv-header__logo {
-  --header-logo-dimensions: 2rem;
+  .cv-header__logo {
+    --header-logo-dimensions: 2rem;
 
-  width: var(--header-logo-dimensions);
-  height: var(--header-logo-dimensions);
-}
+    width: var(--header-logo-dimensions);
+    height: var(--header-logo-dimensions);
+  }
 
-.cv-header__title {
-  margin: 0;
-  font-size: 1.125rem;
-  font-weight: 600;
-  color: var(--cv-black);
-}
+  .cv-header__title {
+    margin: 0;
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: var(--cv-black);
+  }
 
-/* Panel content */
-.cv-panel__content {
-  padding: 1.5rem;
-}
+  /* Panel content */
+  .cv-panel__content {
+    padding: 1.5rem;
+  }
 
-/* Features list & content */
-.cv-feature {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.75rem;
-}
+  /* Features list & content */
+  .cv-feature {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem;
+  }
 
-.cv-feature__icon {
-  font-size: 1.25rem;
-  flex-shrink: 0;
-}
+  .cv-feature__icon {
+    font-size: 1.25rem;
+    flex-shrink: 0;
+  }
 
-.cv-feature__text {
-  color: var(--cv-white);
-  font-weight: 500;
-}
+  .cv-feature__text {
+    color: var(--cv-white);
+    font-weight: 500;
+  }
 
-/* Button */
-.cv-btn {
-  width: 100%;
-  padding: 1rem;
-  border: none;
-  border-radius: 0.5rem;
-  font-size: 1rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s ease;
-}
-
-.cv-btn--primary {
-  background: transparent;
-  color: var(--cv-white);
-  border: 2px solid var(--cv-white);
-}
-
-.cv-btn--primary:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px var(--cv-black);
-}
-
-.cv-btn--primary:active {
-  transform: translateY(0);
-}
-
-.cv-btn:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-  transform: none;
-}
-
-/* Responsive design */
-@media (max-width: 480px) {
-  .cv-panel {
+  /* Button */
+  .cv-btn {
     width: 100%;
+    padding: 1rem;
+    border: none;
+    border-radius: 0.5rem;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
   }
-}
 
-/* High contrast mode support */
-@media (prefers-contrast: more) {
-  .cv-panel {
-    border: 2px solid var(--cv-black);
+  .cv-btn--primary {
+    background: transparent;
+    color: var(--cv-white);
+    border: 2px solid var(--cv-white);
   }
-}
 
-/* Reduced motion support */
-@media (prefers-reduced-motion) {
-  .cv-panel {
-    transition: none;
+  .cv-btn--primary:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px var(--cv-black);
+  }
+
+  .cv-btn--primary:active {
+    transform: translateY(0);
+  }
+
+  .cv-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    transform: none;
+  }
+
+  /* Responsive design */
+  @media (max-width: 480px) {
+    .cv-panel {
+      width: 100%;
+    }
+  }
+
+  /* High contrast mode support */
+  @media (prefers-contrast: more) {
+    .cv-panel {
+      border: 2px solid var(--cv-black);
+    }
+  }
+
+  /* Reduced motion support */
+  @media (prefers-reduced-motion) {
+    .cv-panel {
+      transition: none;
+    }
   }
 }

--- a/src/styles/core.css
+++ b/src/styles/core.css
@@ -1,10 +1,10 @@
 /* Core styles for Carbon Visualizer extension */
 
 :where(#carbon-visualizer-welcome-panel,
-#carbon-visualizer-welcome-panel *,
-#carbon-visualizer-welcome-panel *::before,
-#carbon-visualizer-welcome-panel *::after) {
-  all: initial;
+  #carbon-visualizer-welcome-panel *,
+  #carbon-visualizer-welcome-panel *::before,
+  #carbon-visualizer-welcome-panel *::after) {
+  all: revert;
 }
 
 /* TODO: these green values were generated using https://oklchroma.utilitybend.com/ and are not part of any design specs.
@@ -29,6 +29,16 @@
   /* neutrals */
   --cv-black: hsl(0deg 0% 0%);
   --cv-white: hsl(0deg 0% 100%);
+
+  font-family: var(--cv-font-family-sans);
+
+  :where(h1, h2, h3, h4, h5, h6, p, ul, ol, dl, dt, figure, blockquote) {
+    line-height: calc(1em + 0.5rem);
+
+    &:not(:first-child) {
+      margin-block-start: 1em;
+    }
+  }
 }
 
 .cv-panel {

--- a/src/styles/core.css
+++ b/src/styles/core.css
@@ -1,7 +1,7 @@
 /* Core styles for Carbon Visualizer extension */
 
 #carbon-visualizer-welcome-panel,
-.cv-panel :where(*, *::before, *::after) {
+.cv-panel :where(*, *::before, *::after):not(svg *) {
   all: revert;
 }
 

--- a/src/styles/core.css
+++ b/src/styles/core.css
@@ -1,9 +1,7 @@
 /* Core styles for Carbon Visualizer extension */
 
-:where(#carbon-visualizer-welcome-panel,
-  #carbon-visualizer-welcome-panel *,
-  #carbon-visualizer-welcome-panel *::before,
-  #carbon-visualizer-welcome-panel *::after) {
+#carbon-visualizer-welcome-panel,
+.cv-panel :where(*, *::before, *::after) {
   all: revert;
 }
 

--- a/src/styles/core.css
+++ b/src/styles/core.css
@@ -1,6 +1,6 @@
 /* Core styles for Carbon Visualizer extension */
 
-#carbon-visualizer-welcome-panel,
+.cv-panel,
 .cv-panel :where(*, *::before, *::after):not(svg *) {
   all: revert;
 }
@@ -9,7 +9,7 @@
  * The custom properties are used in this file and welcome.css.
  * Feel free to remove them in favor of our own color palette!
  */
-#carbon-visualizer-welcome-panel {
+.cv-panel {
   /* greens */
   --cv-primary-green: hsl(114deg 64.9% 32.0%);
   --cv-primary-green-base: 0.05;

--- a/src/styles/generic/typography.css
+++ b/src/styles/generic/typography.css
@@ -1,4 +1,4 @@
-#carbon-visualizer-welcome-panel {
+.cv-panel {
   * {
     max-inline-size: var(--cv-max-line-length);
   }

--- a/src/styles/generic/typography.css
+++ b/src/styles/generic/typography.css
@@ -1,4 +1,4 @@
-.cv {
+#carbon-visualizer-welcome-panel {
   * {
     max-inline-size: var(--cv-max-line-length);
   }

--- a/src/styles/results.css
+++ b/src/styles/results.css
@@ -1,28 +1,30 @@
 
 /* Results panel variant styles */
 
-.cv-panel--results {
-  text-align: center;
-  background: linear-gradient(to bottom,var(--cv-primary-green-10), var(--cv-primary-green-70) 80%);
-  color: var(--cv-white);
-}
+#carbon-visualizer-welcome-panel {
+  &.cv-panel--results {
+    text-align: center;
+    background: linear-gradient(to bottom,var(--cv-primary-green-10), var(--cv-primary-green-70) 80%);
+    color: var(--cv-white);
+  }
 
-.cv-results__icon {
-  font-size: 3rem;
-  margin-bottom: 1rem;
-}
+  .cv-results__icon {
+    font-size: 3rem;
+    margin-bottom: 1rem;
+  }
 
-.cv-results__title {
-  margin: 0 0 1rem 0;
-  font-size: 1.25rem;
-  font-weight: 600;
-  color: var(--cv-white);
-}
+  .cv-results__title {
+    margin: 0 0 1rem 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--cv-white);
+  }
 
-.cv-results__description {
-  margin: 0 0 2rem 0;
-  color: var(--cv-white);
-  line-height: 1.5;
+  .cv-results__description {
+    margin: 0 0 2rem 0;
+    color: var(--cv-white);
+    line-height: 1.5;
+  }
 }
 
 .cv-results__sections {

--- a/src/styles/results.css
+++ b/src/styles/results.css
@@ -1,7 +1,6 @@
 
 /* Results panel variant styles */
-
-#carbon-visualizer-welcome-panel {
+#carbon-visualizer-results-panel {
   &.cv-panel--results {
     text-align: center;
     background: linear-gradient(to bottom,var(--cv-primary-green-10), var(--cv-primary-green-70) 80%);
@@ -25,28 +24,28 @@
     color: var(--cv-white);
     line-height: 1.5;
   }
-}
 
-.cv-results__sections {
-  text-align: start;
-  margin-bottom: 2.0rem;
-}
+  .cv-results__sections {
+    text-align: start;
+    margin-bottom: 2.0rem;
+  }
 
-.cv-results__group {
-  padding: 1.0rem;
-  border: 1px solid currentColor;
-  border-inline-start-width: 4px;
-  border-radius: 1.0rem;
-}
+  .cv-results__group {
+    padding: 1.0rem;
+    border: 1px solid currentColor;
+    border-inline-start-width: 4px;
+    border-radius: 1.0rem;
+  }
 
-.cv-results__group > *:first-child {
-  margin-block-start: 0;
-}
+  .cv-results__group > *:first-child {
+    margin-block-start: 0;
+  }
 
-.cv-results__group > *:last-child {
-  margin-block-end: 0;
-}
+  .cv-results__group > *:last-child {
+    margin-block-end: 0;
+  }
 
-.cv-results__details summary {
-  margin-block-end: 0.5rem;
+  .cv-results__details summary {
+    margin-block-end: 0.5rem;
+  }
 }

--- a/src/styles/themes/default.css
+++ b/src/styles/themes/default.css
@@ -1,4 +1,4 @@
-.cv,
+#carbon-visualizer-welcome-panel,
 [data-theme] {
   /* set up light and dark mode colors */
   /* don't use these directly in components */

--- a/src/styles/themes/default.css
+++ b/src/styles/themes/default.css
@@ -1,4 +1,4 @@
-#carbon-visualizer-welcome-panel,
+.cv-panel,
 [data-theme] {
   /* set up light and dark mode colors */
   /* don't use these directly in components */

--- a/src/styles/tokens/color.css
+++ b/src/styles/tokens/color.css
@@ -1,4 +1,4 @@
-.cv {
+#carbon-visualizer-welcome-panel {
   --cv-color-pink: oklch(50.0% 0.200 345);
   --cv-color-pink-base: 0.05;
   --cv-color-pink-10: oklch(from var(--cv-color-pink) 10% calc(var(--cv-color-pink-base) + (sin(1.0 * pi) * c)) h);

--- a/src/styles/tokens/color.css
+++ b/src/styles/tokens/color.css
@@ -1,4 +1,4 @@
-#carbon-visualizer-welcome-panel {
+.cv-panel {
   --cv-color-pink: oklch(50.0% 0.200 345);
   --cv-color-pink-base: 0.05;
   --cv-color-pink-10: oklch(from var(--cv-color-pink) 10% calc(var(--cv-color-pink-base) + (sin(1.0 * pi) * c)) h);

--- a/src/styles/tokens/size.css
+++ b/src/styles/tokens/size.css
@@ -1,4 +1,4 @@
-#carbon-visualizer-welcome-panel {
+.cv-panel {
   --cv-page-gutter: 1.5rem;
   --cv-max-content-width: 75rem;
   --cv-max-line-length: 72ch;

--- a/src/styles/tokens/size.css
+++ b/src/styles/tokens/size.css
@@ -1,4 +1,4 @@
-.cv {
+#carbon-visualizer-welcome-panel {
   --cv-page-gutter: 1.5rem;
   --cv-max-content-width: 75rem;
   --cv-max-line-length: 72ch;

--- a/src/styles/tokens/typography.css
+++ b/src/styles/tokens/typography.css
@@ -1,4 +1,4 @@
-#carbon-visualizer-welcome-panel {
+.cv-panel {
   /* somewhat randomly selected system font stacks from https://modernfontstacks.com/ (replace as needed) */
   --cv-font-family-display: Bahnschrift, 'DIN Alternate', 'Franklin Gothic Medium', 'Nimbus Sans Narrow', sans-serif-condensed, sans-serif;
   --cv-font-family-sans: Seravek, 'Gill Sans Nova', Ubuntu, Calibri, 'DejaVu Sans', source-sans-pro, sans-serif;

--- a/src/styles/tokens/typography.css
+++ b/src/styles/tokens/typography.css
@@ -1,15 +1,15 @@
-.cv {
+#carbon-visualizer-welcome-panel {
   /* somewhat randomly selected system font stacks from https://modernfontstacks.com/ (replace as needed) */
   --cv-font-family-display: Bahnschrift, 'DIN Alternate', 'Franklin Gothic Medium', 'Nimbus Sans Narrow', sans-serif-condensed, sans-serif;
   --cv-font-family-sans: Seravek, 'Gill Sans Nova', Ubuntu, Calibri, 'DejaVu Sans', source-sans-pro, sans-serif;
-  --cv-font-family-serif: Avenir, Montserrat, Corbel, 'URW Gothic', source-sans-pro, sans-serif;
+  --cv-font-family-serif: Rockwell, 'Rockwell Nova', 'Roboto Slab', 'DejaVu Serif', 'Sitka Small', serif;
   --cv-font-family-mono: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
 
   /* commonly needed font sizes, named for what they're used for (avoiding overly specific names like h1, h2, etc.) */
   --cv-font-size-display-lg: 7.25rem;
   --cv-font-size-display-md: 5.5rem;
   --cv-font-size-display-sm: 4rem;
-  --cv-font-size-heading-xxl: 3rem;
+  --cv-font-size-heading-xxl: 2.75rem;
   --cv-font-size-heading-xl: 2.25rem;
   --cv-font-size-heading-lg: 1.75rem;
   --cv-font-size-heading-md: 1.25rem;

--- a/src/styles/welcome.css
+++ b/src/styles/welcome.css
@@ -31,5 +31,6 @@
     flex-direction: column;
     gap: 0.75rem;
     margin-bottom: 2rem;
+    padding-inline: 0;
   }
 }

--- a/src/styles/welcome.css
+++ b/src/styles/welcome.css
@@ -1,33 +1,35 @@
 
 /* Welcome panel variant styles */
 
-.cv-panel--welcome {
-  text-align: center;
-  background: linear-gradient(to bottom,var(--cv-primary-green-10), var(--cv-primary-green-70) 80%);
-  color: var(--cv-white);
-}
+#carbon-visualizer-welcome-panel {
+  &.cv-panel--welcome {
+    text-align: center;
+    background: linear-gradient(to bottom,var(--cv-primary-green-10), var(--cv-primary-green-70) 80%);
+    color: var(--cv-white);
+  }
 
-.cv-panel--welcome__icon {
-  font-size: 3rem;
-  margin-bottom: 1rem;
-}
+  .cv-panel--welcome__icon {
+    font-size: 3rem;
+    margin-bottom: 1rem;
+  }
 
-.cv-panel--welcome__title {
-  margin: 0 0 1rem 0;
-  font-size: 1.25rem;
-  font-weight: 600;
-  color: var(--cv-white);
-}
+  .cv-panel--welcome__title {
+    margin: 0 0 1rem 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--cv-white);
+  }
 
-.cv-panel--welcome__description {
-  margin: 0 0 2rem 0;
-  color: var(--cv-white);
-  line-height: 1.5;
-}
+  .cv-panel--welcome__description {
+    margin: 0 0 2rem 0;
+    color: var(--cv-white);
+    line-height: 1.5;
+  }
 
-.cv-panel--welcome__features {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  margin-bottom: 2rem;
+  .cv-panel--welcome__features {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin-bottom: 2rem;
+  }
 }


### PR DESCRIPTION
## Description

This is meant to prevent page styles from interfering with the panel's styles by reverting all properties within the panel, then setting whatever styles we need. Sites that change the root font size will cause trouble, such as [this one](https://htmlcolors.com/hsl-to-hex), but there's not much we can do to mitigate that (it's bad practice anyway). There may be cases where the specificity of a page's styling for a particular element is higher than the selector that reverts the page styles, but those seem to be rare as far as I can tell.

## To Validate

1. Pull down this branch
2. Run `npm run build`
3. Load the extension in Chrome or Firefox
4. For a random, somewhat comprehensive sample of sites, run the extension and confirm that there are no unintended styles leaking through from the page