### PR TITLE
feat: add loader component

### DIFF
--- a/src/components/Loader.js
+++ b/src/components/Loader.js
@@ -1,0 +1,17 @@
+export const createLoader = () => {
+  const container = document.createElement('div');
+  container.classList.add('cv-loader');
+
+  const label = document.createElement('label');
+  label.classList.add('cv-loader__label');
+  label.innerHTML = "Calculation in progress...";
+  label.setAttribute('for', 'cv-progress');
+
+  const loader = document.createElement('progress');
+  loader.classList.add('cv-loader__progress');
+  loader.setAttribute('id', 'cv-progress');
+
+  container.append(label, loader);
+
+  return container;
+}

--- a/src/panels/welcome/welcome.js
+++ b/src/panels/welcome/welcome.js
@@ -2,6 +2,7 @@
 import { extensionManager } from "../../core/ExtensionManager.js";
 import { makePageSpeedAPIRequest } from "../../core/PageSpeedService.js";
 import { calculateEmissionsFromPageSpeedResults } from "../../core/CarbonCalculator.bundle.js";
+import { createLoader } from "../../components/Loader.js";
 
 export function initializePanel(panelType, data) {
   // Get the container element
@@ -31,6 +32,11 @@ export function initializePanel(panelType, data) {
     if (analyzeErrorMessage) {
       analyzeErrorMessage.textContent = '';
     }
+
+    // ! Drop below
+    const loader = createLoader();
+    analyzeBtn.insertAdjacentElement('beforebegin', loader);
+    // ! Drop above
 
     // Make API request.
     const currentPageURL = window.location.toString();

--- a/src/styles/core.css
+++ b/src/styles/core.css
@@ -137,6 +137,20 @@
     transform: none;
   }
 
+  /* Loader */
+  .cv-loader {
+    display: flex;
+    gap: 0.5rem;
+    margin: 1rem;
+    flex-direction: column-reverse;
+    align-items: center;
+    color: var(--cv-color-gray-100);
+  }
+
+  .cv-loader__progress {
+    accent-color: var(--cv-color-gray-20);
+  }
+
   /* Responsive design */
   @media (max-width: 480px) {
     .cv-panel {


### PR DESCRIPTION
This work adds a loader component. I added a drop commit where clicking the analyze button will make the loader appear while the calculator is working to at least get it on the page pre-implementation. If you want to look at it on its own, I replicated it on [Codepen](https://codepen.io/arnest00/pen/XJKzvod). You'll want to take a look in Firefox, Chrome, and Safari - the `progress` element in its indeterminate state has slightly different behavior in each browser.

## Relevant links
- [BLDL-21](https://sparkbox.atlassian.net/browse/BLDL-21)

## To validate
1. Pull down `feat--loader-component`
1. Run `npm i` and `npm run build`
1. Load the extension into either Chrome or Firefox
1. Verify you can open the extension
1. Click on the "Analyze this page" button
1. Verify loader component appears above the button as the calculation finishes

[BLDL-21]: https://sparkbox.atlassian.net/browse/BLDL-21?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ